### PR TITLE
Add dropdown for About section

### DIFF
--- a/About/Cabinet/index.html
+++ b/About/Cabinet/index.html
@@ -19,7 +19,14 @@
       <h1>SGA Cabinet</h1>
       <nav>
         <a href="/">Home</a>
-        <a href="/About/">About</a>
+        <div class="dropdown">
+          <a href="/About/">About</a>
+          <div class="dropdown-content">
+            <a href="/About/Executives/">Executive Officers</a>
+            <a href="/About/Cabinet/">Cabinet</a>
+            <a href="/About/Senators/">Senators</a>
+          </div>
+        </div>
         <a href="/Events/">Events</a>
         <a href="/Media/">Media</a>
         <a href="/Idea/">Submit Idea</a>

--- a/About/Executives/index.html
+++ b/About/Executives/index.html
@@ -19,7 +19,14 @@
       <h1>Executive Officers</h1>
       <nav>
         <a href="/">Home</a>
-        <a href="/About/">About</a>
+        <div class="dropdown">
+          <a href="/About/">About</a>
+          <div class="dropdown-content">
+            <a href="/About/Executives/">Executive Officers</a>
+            <a href="/About/Cabinet/">Cabinet</a>
+            <a href="/About/Senators/">Senators</a>
+          </div>
+        </div>
         <a href="/Events/">Events</a>
         <a href="/Media/">Media</a>
         <a href="/Idea/">Submit Idea</a>

--- a/About/Senators/index.html
+++ b/About/Senators/index.html
@@ -19,7 +19,14 @@
       <h1>Senators</h1>
       <nav>
         <a href="/">Home</a>
-        <a href="/About/">About</a>
+        <div class="dropdown">
+          <a href="/About/">About</a>
+          <div class="dropdown-content">
+            <a href="/About/Executives/">Executive Officers</a>
+            <a href="/About/Cabinet/">Cabinet</a>
+            <a href="/About/Senators/">Senators</a>
+          </div>
+        </div>
         <a href="/Events/">Events</a>
         <a href="/Media/">Media</a>
         <a href="/Idea/">Submit Idea</a>

--- a/About/index.html
+++ b/About/index.html
@@ -20,7 +20,14 @@
       <h1>Get to Know the SGA</h1>
       <nav>
         <a href="/">Home</a>
-        <a href="/About/">About</a>
+        <div class="dropdown">
+          <a href="/About/">About</a>
+          <div class="dropdown-content">
+            <a href="/About/Executives/">Executive Officers</a>
+            <a href="/About/Cabinet/">Cabinet</a>
+            <a href="/About/Senators/">Senators</a>
+          </div>
+        </div>
         <a href="/Events/">Events</a>
         <a href="/Media/">Media</a>
         <a href="/Idea/">Submit Idea</a>

--- a/Contact/index.html
+++ b/Contact/index.html
@@ -19,7 +19,14 @@
       <h1>Contact Us</h1>
       <nav>
         <a href="/">Home</a>
-        <a href="/About/">About</a>
+        <div class="dropdown">
+          <a href="/About/">About</a>
+          <div class="dropdown-content">
+            <a href="/About/Executives/">Executive Officers</a>
+            <a href="/About/Cabinet/">Cabinet</a>
+            <a href="/About/Senators/">Senators</a>
+          </div>
+        </div>
         <a href="/Events/">Events</a>
         <a href="/Media/">Media</a>
         <a href="/Idea/">Submit Idea</a>

--- a/Events/index.html
+++ b/Events/index.html
@@ -19,13 +19,20 @@
 <header>
 <h1>SGA Events</h1>
 <nav>
-<a href="/">Home</a>
-<a href="/About/">About</a>
-<a href="/Events/">Events</a>
-<a href="/Media/">Media</a>
-<a href="/Idea/">Submit Idea</a>
-<a href="/Contact/">Contact</a>
-</nav>
+        <a href="/">Home</a>
+        <div class="dropdown">
+          <a href="/About/">About</a>
+          <div class="dropdown-content">
+            <a href="/About/Executives/">Executive Officers</a>
+            <a href="/About/Cabinet/">Cabinet</a>
+            <a href="/About/Senators/">Senators</a>
+          </div>
+        </div>
+        <a href="/Events/">Events</a>
+        <a href="/Media/">Media</a>
+        <a href="/Idea/">Submit Idea</a>
+        <a href="/Contact/">Contact</a>
+      </nav>
 </header>
 <main>
         <h2>SGA Calendar</h2>

--- a/Idea/index.html
+++ b/Idea/index.html
@@ -19,7 +19,14 @@
       <h1>Submit Idea</h1>
       <nav>
         <a href="/">Home</a>
-        <a href="/About/">About</a>
+        <div class="dropdown">
+          <a href="/About/">About</a>
+          <div class="dropdown-content">
+            <a href="/About/Executives/">Executive Officers</a>
+            <a href="/About/Cabinet/">Cabinet</a>
+            <a href="/About/Senators/">Senators</a>
+          </div>
+        </div>
         <a href="/Events/">Events</a>
         <a href="/Media/">Media</a>
         <a href="/Idea/">Submit Idea</a>

--- a/Media/index.html
+++ b/Media/index.html
@@ -20,13 +20,20 @@
 <header>
 <h1>Pictures and Videos</h1>
 <nav>
-<a href="/">Home</a>
-<a href="/About/">About</a>
-<a href="/Events/">Events</a>
-<a href="/Media/">Media</a>
-<a href="/Idea/">Submit Idea</a>
-<a href="/Contact/">Contact</a>
-</nav>
+        <a href="/">Home</a>
+        <div class="dropdown">
+          <a href="/About/">About</a>
+          <div class="dropdown-content">
+            <a href="/About/Executives/">Executive Officers</a>
+            <a href="/About/Cabinet/">Cabinet</a>
+            <a href="/About/Senators/">Senators</a>
+          </div>
+        </div>
+        <a href="/Events/">Events</a>
+        <a href="/Media/">Media</a>
+        <a href="/Idea/">Submit Idea</a>
+        <a href="/Contact/">Contact</a>
+      </nav>
 </header>
 <main>
 <h2>SGA Media</h2>

--- a/css/styles.css
+++ b/css/styles.css
@@ -68,6 +68,36 @@ nav a {
   font-weight: bold;
 }
 
+nav .dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+nav .dropdown-content {
+  display: none;
+  position: absolute;
+  background: var(--primary);
+  padding: 0.5rem 0;
+  min-width: 160px;
+  z-index: 1;
+}
+
+nav .dropdown-content a {
+  display: block;
+  margin: 0;
+  padding: 0.5rem 1rem;
+  color: var(--light);
+  text-align: left;
+}
+
+nav .dropdown-content a:hover {
+  background: var(--secondary);
+}
+
+nav .dropdown:hover .dropdown-content {
+  display: block;
+}
+
 main {
   padding: 2rem;
   flex: 1;

--- a/index.html
+++ b/index.html
@@ -53,7 +53,14 @@
       <h1>Home</h1>
       <nav>
         <a href="/">Home</a>
-        <a href="/About/">About</a>
+        <div class="dropdown">
+          <a href="/About/">About</a>
+          <div class="dropdown-content">
+            <a href="/About/Executives/">Executive Officers</a>
+            <a href="/About/Cabinet/">Cabinet</a>
+            <a href="/About/Senators/">Senators</a>
+          </div>
+        </div>
         <a href="/Events/">Events</a>
         <a href="/Media/">Media</a>
         <a href="/Idea/">Submit Idea</a>


### PR DESCRIPTION
## Summary
- Convert About nav link into hoverable dropdown that lists Executive Officers, Cabinet, and Senators pages
- Style dropdown menu with new CSS rules

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ce450682c8328bc5568debe60fb58