### PR TITLE
feat: add parallax hero header

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -20,6 +20,10 @@ body {
   height: 100%;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   margin: 0;
   font-family: 'Poppins', sans-serif;
@@ -38,31 +42,54 @@ body {
   min-height: 100vh;
 }
 
-/* Header / Navigation */
+/* Hero Header / Navigation */
 
 header {
-  background: var(--primary);
+  position: relative;
+  height: 100vh;
   color: var(--light);
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-  padding: 1rem 2rem;
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: 1rem;
+  justify-content: center;
+  text-align: center;
+  background-image: url('https://images.unsplash.com/photo-1523050854058-8df90110c9f1?auto=format&fit=crop&w=1400&q=80');
+  background-size: cover;
+  background-position: center;
+  background-attachment: fixed;
 }
 
-@media (min-width: 600px) {
-  header {
-    flex-direction: row;
-    justify-content: space-between;
-  }
+header::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+}
+
+header h1 {
+  position: relative;
+  z-index: 1;
+  font-size: clamp(2.5rem, 6vw, 4rem);
+  margin: 0;
 }
 
 nav {
+  position: absolute;
+  top: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
   justify-content: center;
+  z-index: 2;
+}
+
+@media (min-width: 600px) {
+  nav {
+    left: auto;
+    right: 2rem;
+    transform: none;
+  }
 }
 
 nav a {
@@ -71,6 +98,8 @@ nav a {
   border-radius: 6px;
   text-decoration: none;
   font-weight: 600;
+  backdrop-filter: blur(2px);
+  background-color: rgba(0, 0, 0, 0.2);
   transition: background-color 0.3s ease, color 0.3s ease;
 }
 
@@ -89,7 +118,7 @@ nav .dropdown-content {
   position: absolute;
   top: 100%;
   left: 0;
-  background: var(--primary);
+  background: rgba(0, 40, 85, 0.9);
   border-radius: 6px;
   min-width: 180px;
   padding: 0.5rem 0;
@@ -102,6 +131,7 @@ nav .dropdown-content a {
   margin: 0;
   padding: 0.5rem 1rem;
   color: var(--light);
+  background: transparent;
 }
 
 nav .dropdown-content a:hover {


### PR DESCRIPTION
## Summary
- overhaul header into full-screen hero with parallax background image
- overlay navigation bar with modern styling and smooth scroll behavior

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e5573a47483288fb0b17bebf08af3