### PR TITLE
Fix navigation overlap on page headers

### DIFF
--- a/About/Cabinet/index.html
+++ b/About/Cabinet/index.html
@@ -17,7 +17,6 @@
 <body>
   <div class="wrapper">
     <header>
-      <h1>SGA Cabinet</h1>
       <nav>
         <a href="/">Home</a>
         <div class="dropdown">
@@ -33,6 +32,9 @@
         <a href="/Idea/">Submit Idea</a>
         <a href="/Contact/">Contact</a>
       </nav>
+      <div class="hero-content">
+        <h1>SGA Cabinet</h1>
+      </div>
     </header>
 
     <main>

--- a/About/Executives/index.html
+++ b/About/Executives/index.html
@@ -17,7 +17,6 @@
 <body>
   <div class="wrapper">
     <header>
-      <h1>Executive Officers</h1>
       <nav>
         <a href="/">Home</a>
         <div class="dropdown">
@@ -33,6 +32,9 @@
         <a href="/Idea/">Submit Idea</a>
         <a href="/Contact/">Contact</a>
       </nav>
+      <div class="hero-content">
+        <h1>Executive Officers</h1>
+      </div>
     </header>
 
     <main>

--- a/About/Senators/index.html
+++ b/About/Senators/index.html
@@ -16,7 +16,6 @@
 <body>
   <div class="wrapper">
     <header>
-      <h1>Senators</h1>
       <nav>
         <a href="/">Home</a>
         <div class="dropdown">
@@ -32,6 +31,9 @@
         <a href="/Idea/">Submit Idea</a>
         <a href="/Contact/">Contact</a>
       </nav>
+      <div class="hero-content">
+        <h1>Senators</h1>
+      </div>
     </header>
 
     <main>

--- a/About/index.html
+++ b/About/index.html
@@ -17,7 +17,6 @@
 <body>
   <div class="wrapper">
     <header>
-      <h1>Get to Know the SGA</h1>
       <nav>
         <a href="/">Home</a>
         <div class="dropdown">
@@ -33,6 +32,9 @@
         <a href="/Idea/">Submit Idea</a>
         <a href="/Contact/">Contact</a>
       </nav>
+      <div class="hero-content">
+        <h1>Get to Know the SGA</h1>
+      </div>
     </header>
 
     <main>

--- a/Contact/index.html
+++ b/Contact/index.html
@@ -17,7 +17,6 @@
 <body>
   <div class="wrapper">
     <header>
-      <h1>Contact Us</h1>
       <nav>
         <a href="/">Home</a>
         <div class="dropdown">
@@ -33,6 +32,9 @@
         <a href="/Idea/">Submit Idea</a>
         <a href="/Contact/">Contact</a>
       </nav>
+      <div class="hero-content">
+        <h1>Contact Us</h1>
+      </div>
     </header>
 
     <main>

--- a/Events/index.html
+++ b/Events/index.html
@@ -19,7 +19,6 @@
 <body>
 <div class="wrapper">
 <header>
-<h1>SGA Events</h1>
 <nav>
         <a href="/">Home</a>
         <div class="dropdown">
@@ -35,6 +34,9 @@
         <a href="/Idea/">Submit Idea</a>
         <a href="/Contact/">Contact</a>
       </nav>
+      <div class="hero-content">
+        <h1>SGA Events</h1>
+      </div>
 </header>
 <main>
         <h2>SGA Calendar</h2>

--- a/Idea/index.html
+++ b/Idea/index.html
@@ -18,7 +18,6 @@
 <body>
   <div class="wrapper">
     <header>
-      <h1>Submit Idea</h1>
       <nav>
         <a href="/">Home</a>
         <div class="dropdown">
@@ -34,6 +33,9 @@
         <a href="/Idea/">Submit Idea</a>
         <a href="/Contact/">Contact</a>
       </nav>
+      <div class="hero-content">
+        <h1>Submit Idea</h1>
+      </div>
     </header>
 
     <main>

--- a/Media/index.html
+++ b/Media/index.html
@@ -19,7 +19,6 @@
 <body>
 <div class="wrapper">
 <header>
-<h1>Pictures and Videos</h1>
 <nav>
         <a href="/">Home</a>
         <div class="dropdown">
@@ -35,6 +34,9 @@
         <a href="/Idea/">Submit Idea</a>
         <a href="/Contact/">Contact</a>
       </nav>
+      <div class="hero-content">
+        <h1>Pictures and Videos</h1>
+      </div>
 </header>
 <main>
 <h2>SGA Media</h2>


### PR DESCRIPTION
## Summary
- move navigation menu above headers for non-home pages and wrap headings in hero-content to prevent overlap and improve alignment

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688eb2bc75ac832895159af5efe12396