### PR TITLE
fix: keep navigation from covering headings

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -46,11 +46,12 @@ body {
 
 header {
   position: relative;
-  height: 100vh;
+  min-height: 100vh;
   color: var(--light);
   display: flex;
+  flex-direction: column;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   text-align: center;
   background-image: url('https://images.unsplash.com/photo-1523050854058-8df90110c9f1?auto=format&fit=crop&w=1400&q=80');
   background-size: cover;
@@ -73,10 +74,7 @@ header h1 {
 }
 
 nav {
-  position: absolute;
-  top: 1rem;
-  left: 50%;
-  transform: translateX(-50%);
+  margin-top: 1rem;
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
@@ -86,9 +84,8 @@ nav {
 
 @media (min-width: 600px) {
   nav {
-    left: auto;
-    right: 2rem;
-    transform: none;
+    align-self: flex-end;
+    margin-right: 2rem;
   }
 }
 
@@ -189,6 +186,11 @@ main {
 .hero-content {
   position: relative;
   z-index: 1;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   text-align: center;
   padding: 0 1rem;
 }


### PR DESCRIPTION
## Summary
- ensure nav bar sits above hero headings instead of overlaying them
- center hero text with flexible layout

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688eb997ea4c8328a25df13509d9dd68