### PR TITLE
Make home sections full screen with scroll reveal

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -217,13 +217,13 @@ main {
 
 /* Feature cards */
 
-.features {
-  display: grid;
-  gap: 2rem;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  max-width: 1200px;
-  margin: 4rem auto;
-  padding: 0 1rem;
+
+.full-section {
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
 }
 
 .feature {

--- a/index.html
+++ b/index.html
@@ -50,20 +50,26 @@
 
     <!-- Main Content -->
     <main>
-      <section class="features">
-        <div class="feature reveal">
+      <section class="full-section reveal">
+        <div class="feature">
           <i class="fa-solid fa-comments"></i>
           <h3>Share Your Voice</h3>
           <p>Submit feedback and ideas to help shape campus life.</p>
           <a class="button" href="/Idea/">Submit an Idea</a>
         </div>
-        <div class="feature reveal">
+      </section>
+
+      <section class="full-section reveal">
+        <div class="feature">
           <i class="fa-solid fa-calendar-days"></i>
           <h3>Get Involved</h3>
           <p>Join us at upcoming events and make new connections.</p>
           <a class="button" href="/Events/">See Events</a>
         </div>
-        <div class="feature reveal">
+      </section>
+
+      <section class="full-section reveal">
+        <div class="feature">
           <i class="fa-solid fa-users"></i>
           <h3>Meet the Team</h3>
           <p>Learn more about the students representing you.</p>
@@ -71,7 +77,7 @@
         </div>
       </section>
 
-      <section class="cta reveal">
+      <section class="cta reveal full-section">
         <h2>Ready to make a difference?</h2>
         <a class="button" href="/Contact/">Contact Us</a>
       </section>

--- a/js/main.js
+++ b/js/main.js
@@ -6,11 +6,12 @@ document.addEventListener("DOMContentLoaded", () => {
 
   const reveals = document.querySelectorAll(".reveal");
   if (reveals.length) {
-    const observer = new IntersectionObserver((entries, obs) => {
+    const observer = new IntersectionObserver((entries) => {
       entries.forEach(entry => {
         if (entry.isIntersecting) {
           entry.target.classList.add("visible");
-          obs.unobserve(entry.target);
+        } else {
+          entry.target.classList.remove("visible");
         }
       });
     }, { threshold: 0.2 });
@@ -77,33 +78,6 @@ document.addEventListener("DOMContentLoaded", () => {
       },
       { passive: true }
     );
-  }
-});
-
-document.addEventListener("DOMContentLoaded", () => {
-  console.log("CSU SGA site loaded.");
-
-  const reveals = document.querySelectorAll(".reveal");
-  if (reveals.length) {
-    const observer = new IntersectionObserver((entries, obs) => {
-      entries.forEach(entry => {
-        if (entry.isIntersecting) {
-          entry.target.classList.add("visible");
-          obs.unobserve(entry.target);
-        }
-      });
-    }, { threshold: 0.2 });
-    reveals.forEach(el => observer.observe(el));
-  }
-
-  const form = document.querySelector("form");
-  if (form) {
-    form.addEventListener("submit", function (e) {
-      if (cooldown) {
-        e.preventDefault();
-        alert("⏱ Please wait 60 seconds before submitting again.");
-      }
-    });
   }
 });
 


### PR DESCRIPTION
## Summary
- Split homepage features into individual full-page sections
- Add shared full-section styling for viewport-height blocks
- Toggle reveal animations on scroll using IntersectionObserver

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ebdba659083289381ac64a5ae5bdb