### PR TITLE
Separate cabinet and senator sections

### DIFF
--- a/About/index.html
+++ b/About/index.html
@@ -43,19 +43,19 @@
     <section id="cabinet" class="about-section snap-section">
       <h2>SGA Cabinet</h2>
       <p>The Cabinet assists the executives and leads key SGA initiatives throughout the year.</p>
+      <div class="members-grid">
+        <div class="member-card">Cabinet member listings coming soon.</div>
+      </div>
     </section>
 
     <section id="senators" class="about-section snap-section">
       <h2>Senators</h2>
       <p>Senators represent each graduating class and advocate for the needs of the student body.</p>
-      <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6248477852052872"
-     crossorigin="anonymous"></script>
-<ins class="adsbygoogle"
-     style="display:block; text-align:center;"
-     data-ad-layout="in-article"
-     data-ad-format="fluid"
-     data-ad-client="ca-pub-6248477852052872"
-     data-ad-slot="1182145108"></ins>
+      <div class="members-grid">
+        <div class="member-card">Senator listings coming soon.</div>
+      </div>
+      <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-6248477852052872" crossorigin="anonymous"></script>
+<ins class="adsbygoogle" style="display:block; text-align:center;" data-ad-layout="in-article" data-ad-format="fluid" data-ad-client="ca-pub-6248477852052872" data-ad-slot="1182145108"></ins>
 <script>
      (adsbygoogle = window.adsbygoogle || []).push({});
 </script>

--- a/css/styles.css
+++ b/css/styles.css
@@ -434,6 +434,22 @@ footer {
   }
 }
 
+/* Member grid styles for cabinet and senator sections */
+.members-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.member-card {
+  background: var(--light);
+  padding: 1rem;
+  border-radius: 8px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  text-align: center;
+}
+
 /* Scroll-to-top button */
 .scroll-top {
   position: fixed;


### PR DESCRIPTION
## Summary
- Add distinct Cabinet and Senator sections on the About page
- Introduce member grid structure for both sections
- Style grids and cards for future member profiles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689260c062dc832891799a278d9d9124