### PR TITLE
Add scroll-to-top arrow indicator

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -434,3 +434,30 @@ footer {
   }
 }
 
+/* Scroll-to-top button */
+.scroll-top {
+  position: fixed;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 40px;
+  height: 40px;
+  border: none;
+  border-radius: 50%;
+  background: var(--primary);
+  color: var(--light);
+  font-size: 1.25rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+
+.scroll-top.show {
+  opacity: 1;
+  pointer-events: auto;
+}
+

--- a/js/main.js
+++ b/js/main.js
@@ -4,6 +4,25 @@ let submitted = false;
 document.addEventListener("DOMContentLoaded", () => {
   console.log("CSU SGA site loaded.");
 
+  // Scroll-to-top button
+  const scrollBtn = document.createElement('button');
+  scrollBtn.className = 'scroll-top';
+  scrollBtn.setAttribute('aria-label', 'Scroll to top');
+  scrollBtn.textContent = '^';
+  document.body.appendChild(scrollBtn);
+
+  scrollBtn.addEventListener('click', () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  });
+
+  window.addEventListener('scroll', () => {
+    if (window.scrollY > 200) {
+      scrollBtn.classList.add('show');
+    } else {
+      scrollBtn.classList.remove('show');
+    }
+  });
+
   const reveals = document.querySelectorAll(".reveal");
   if (reveals.length) {
     const observer = new IntersectionObserver((entries) => {


### PR DESCRIPTION
## Summary
- Introduce scroll-to-top button that appears after the user scrolls down, enabling smooth return to the page top.
- Style the button to match site theme, remain hidden until triggered, and center it at the bottom of the page.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688eca5dfd848328bea4cf251e41a272