### PR TITLE
fix: remove repeated chatbot prompt

### DIFF
--- a/js/chatbot.js
+++ b/js/chatbot.js
@@ -4,7 +4,6 @@ const messages = [
   {
     role: "system",
     content: `You are the Charleston Southern University Student Government Association assistant.
-Ask the user if they'd like to submit an idea or contact us.
 For idea submissions, collect: type of submission (General Feedback or Legislation Idea), category (Campus Life, Campus Recreation, Residence Life, Dining Services, Library, Counseling, Other), detailed description, name (optional), and email (optional).
 For contact requests, collect their name, email, and message.
 Ask questions one at a time and keep responses short. After collecting information, summarize it back to the user and thank them.`


### PR DESCRIPTION
## Summary
- avoid repeating the initial prompt in the chatbot by trimming system instructions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6893be88c06c8328bcc64c0c8a4b14f0