### PR TITLE
Add executive login and content management

### DIFF
--- a/About/index.html
+++ b/About/index.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
   <script src="/js/main.js" defer></script>
   <script src="/js/chatbot.js" defer></script>
+  <script src="/js/content.js" defer></script>
   <link href="https://fonts.googleapis.com" rel="preconnect"/>
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet"/>
@@ -36,22 +37,19 @@
     <section id="executives" class="about-section snap-section">
       <h2>Executive Officers</h2>
       <p>Our executive officers oversee all operations of the Student Government Association.</p>
+      <div id="executives-list" class="members-grid"></div>
     </section>
 
     <section id="cabinet" class="about-section snap-section">
       <h2>SGA Cabinet</h2>
       <p>The Cabinet assists the executives and leads key SGA initiatives throughout the year.</p>
-      <div class="members-grid">
-        <div class="member-card">Cabinet member listings coming soon.</div>
-      </div>
+      <div id="cabinet-list" class="members-grid"></div>
     </section>
 
     <section id="senators" class="about-section snap-section">
       <h2>Senators</h2>
       <p>Senators represent each graduating class and advocate for the needs of the student body.</p>
-      <div class="members-grid">
-        <div class="member-card">Senator listings coming soon.</div>
-      </div>
+      <div id="senators-list" class="members-grid"></div>
     </section>
 
     <footer class="snap-section">

--- a/Events/index.html
+++ b/Events/index.html
@@ -10,6 +10,7 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
 <script src="/js/main.js" defer></script>
 <script src="/js/chatbot.js" defer></script>
+<script src="/js/content.js" defer></script>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
 <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&amp;display=swap" rel="stylesheet"/>
@@ -29,15 +30,16 @@
 </header>
 <main>
         <h2>SGA Calendar</h2>
-	<iframe src="https://calendar.google.com/calendar/embed?height=600&wkst=1&ctz=America%2FNew_York&title=SGA%20Events&src=MmQ0NzBkMGE1M2M2MjJlMWY5OGRmNGExOWU5MzQ0MmU4ZDRhM2Y4ZjQwNjc1YzdjYjk5YzJmMDFjZjlkY2Y4OUBncm91cC5jYWxlbmRhci5nb29nbGUuY29t&color=%23616161" style="border:solid 1px #777" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+        <iframe src="https://calendar.google.com/calendar/embed?height=600&wkst=1&ctz=America%2FNew_York&title=SGA%20Events&src=MmQ0NzBkMGE1M2M2MjJlMWY5OGRmNGExOWU5MzQ0MmU4ZDRhM2Y4ZjQwNjc1YzdjYjk5YzJmMDFjZjlkY2Y4OUBncm91cC5jYWxlbmRhci5nb29nbGUuY29t&color=%23616161" style="border:solid 1px #777" width="800" height="600" frameborder="0" scrolling="no"></iframe>
+        <ul id="events-list"></ul>
         <p>You can view all of our upcoming events using the button below:</p>
-	<a 
-	  class="button" 
-	  href="https://calendar.google.com/calendar/embed?height=600&wkst=1&ctz=America%2FNew_York&title=SGA%20Events&src=MmQ0NzBkMGE1M2M2MjJlMWY5OGRmNGExOWU5MzQ0MmU4ZDRhM2Y4ZjQwNjc1YzdjYjk5YzJmMDFjZjlkY2Y4OUBncm91cC5jYWxlbmRhci5nb29nbGUuY29t&color=%23616161" 
-	  target="_blank" 
-	  rel="noopener noreferrer">
-	  📅 View Full Calendar
-	</a>
+        <a
+          class="button"
+          href="https://calendar.google.com/calendar/embed?height=600&wkst=1&ctz=America%2FNew_York&title=SGA%20Events&src=MmQ0NzBkMGE1M2M2MjJlMWY5OGRmNGExOWU5MzQ0MmU4ZDRhM2Y4ZjQwNjc1YzdjYjk5YzJmMDFjZjlkY2Y4OUBncm91cC5jYWxlbmRhci5nb29nbGUuY29t&color=%23616161"
+          target="_blank"
+          rel="noopener noreferrer">
+          📅 View Full Calendar
+        </a>
   </main>
 <footer>
 <p>© 2025 Charleston Southern University Student Government Association. All rights reserved.</p>

--- a/Media/index.html
+++ b/Media/index.html
@@ -10,6 +10,7 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
 <script src="/js/main.js" defer></script>
 <script src="/js/chatbot.js" defer></script>
+<script src="/js/content.js" defer></script>
 <link href="https://fonts.googleapis.com" rel="preconnect"/>
 <link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
 <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&amp;display=swap" rel="stylesheet"/>
@@ -30,6 +31,7 @@
 <main>
 <h2>SGA Media</h2>
 <p>Check out photos and videos from SGA events!</p>
+<div id="media-list"></div>
 <!-- Replace the ID below with your actual Google Drive folder ID -->
 <iframe src="https://drive.google.com/embeddedfolderview?id=1Kjh1wiMo3Lk5mHZxHJ_f39aYPpD92KoK#grid" style="width:150%; height:1000px; border:0;">
 </iframe>

--- a/admin.html
+++ b/admin.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Executive Admin</title>
+  <link rel="stylesheet" href="/css/styles.css" />
+  <script src="/js/admin.js" defer></script>
+</head>
+<body>
+  <div class="wrapper">
+    <h1>Executive Login</h1>
+    <div id="login">
+      <input id="username" placeholder="Username" />
+      <input id="password" type="password" placeholder="Password" />
+      <button id="login-btn">Login</button>
+    </div>
+    <div id="editor" style="display:none;">
+      <h2>Executives</h2>
+      <div id="executives-form"></div>
+      <button id="add-executive">Add Executive</button>
+      <h2>Cabinet</h2>
+      <div id="cabinet-form"></div>
+      <button id="add-cabinet">Add Cabinet Member</button>
+      <h2>Senators</h2>
+      <div id="senators-form"></div>
+      <button id="add-senator">Add Senator</button>
+      <h2>Events</h2>
+      <div id="events-form"></div>
+      <button id="add-event">Add Event</button>
+      <h2>Media</h2>
+      <div id="media-form"></div>
+      <button id="add-media">Add Media Item</button>
+      <div style="margin-top:1rem;">
+        <button id="save-btn">Save All</button>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/content.json
+++ b/content.json
@@ -1,0 +1,9 @@
+{
+  "personnel": {
+    "executives": [],
+    "cabinet": [],
+    "senators": []
+  },
+  "events": [],
+  "media": []
+}

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,0 +1,112 @@
+let token = localStorage.getItem('token');
+let contentData = null;
+
+async function apiLogin(username, password) {
+  const res = await fetch('/api/login', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username, password })
+  });
+  if (!res.ok) throw new Error('Login failed');
+  const data = await res.json();
+  token = data.token;
+  localStorage.setItem('token', token);
+}
+
+async function loadContent() {
+  const res = await fetch('/api/content');
+  contentData = await res.json();
+}
+
+function createEntry(container, item, fields) {
+  const div = document.createElement('div');
+  fields.forEach(f => {
+    const input = document.createElement('input');
+    input.placeholder = f.charAt(0).toUpperCase() + f.slice(1);
+    input.value = item[f] || '';
+    input.addEventListener('input', e => {
+      item[f] = e.target.value;
+    });
+    div.appendChild(input);
+  });
+  container.appendChild(div);
+}
+
+function renderSection(containerId, items, fields) {
+  const container = document.getElementById(containerId);
+  container.innerHTML = '';
+  items.forEach(item => createEntry(container, item, fields));
+}
+
+function renderAll() {
+  renderSection('executives-form', contentData.personnel.executives, ['name', 'role']);
+  renderSection('cabinet-form', contentData.personnel.cabinet, ['name', 'role']);
+  renderSection('senators-form', contentData.personnel.senators, ['name', 'role']);
+  renderSection('events-form', contentData.events, ['date', 'title']);
+  renderSection('media-form', contentData.media, ['url']);
+}
+
+async function saveContent() {
+  const res = await fetch('/api/content', {
+    method: 'PUT',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`
+    },
+    body: JSON.stringify(contentData)
+  });
+  if (res.ok) {
+    alert('Saved');
+  } else {
+    alert('Save failed');
+  }
+}
+
+function addHandlers() {
+  document.getElementById('add-executive').addEventListener('click', () => {
+    contentData.personnel.executives.push({ name: '', role: '' });
+    renderAll();
+  });
+  document.getElementById('add-cabinet').addEventListener('click', () => {
+    contentData.personnel.cabinet.push({ name: '', role: '' });
+    renderAll();
+  });
+  document.getElementById('add-senator').addEventListener('click', () => {
+    contentData.personnel.senators.push({ name: '', role: '' });
+    renderAll();
+  });
+  document.getElementById('add-event').addEventListener('click', () => {
+    contentData.events.push({ date: '', title: '' });
+    renderAll();
+  });
+  document.getElementById('add-media').addEventListener('click', () => {
+    contentData.media.push({ url: '' });
+    renderAll();
+  });
+  document.getElementById('save-btn').addEventListener('click', saveContent);
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  document.getElementById('login-btn').addEventListener('click', async () => {
+    const u = document.getElementById('username').value;
+    const p = document.getElementById('password').value;
+    try {
+      await apiLogin(u, p);
+      await loadContent();
+      document.getElementById('login').style.display = 'none';
+      document.getElementById('editor').style.display = 'block';
+      renderAll();
+      addHandlers();
+    } catch (e) {
+      alert('Login failed');
+    }
+  });
+
+  if (token) {
+    await loadContent();
+    document.getElementById('login').style.display = 'none';
+    document.getElementById('editor').style.display = 'block';
+    renderAll();
+    addHandlers();
+  }
+});

--- a/js/content.js
+++ b/js/content.js
@@ -1,0 +1,51 @@
+document.addEventListener('DOMContentLoaded', async () => {
+  const res = await fetch('/api/content');
+  const data = await res.json();
+
+  if (document.getElementById('executives-list')) {
+    renderMembers('executives-list', data.personnel.executives);
+    renderMembers('cabinet-list', data.personnel.cabinet);
+    renderMembers('senators-list', data.personnel.senators);
+  }
+
+  if (document.getElementById('events-list')) {
+    renderEvents('events-list', data.events);
+  }
+
+  if (document.getElementById('media-list')) {
+    renderMedia('media-list', data.media);
+  }
+});
+
+function renderMembers(id, members) {
+  const container = document.getElementById(id);
+  container.innerHTML = '';
+  members.forEach(m => {
+    const div = document.createElement('div');
+    div.className = 'member-card';
+    div.textContent = `${m.name} - ${m.role}`;
+    container.appendChild(div);
+  });
+}
+
+function renderEvents(id, events) {
+  const container = document.getElementById(id);
+  container.innerHTML = '';
+  events.forEach(e => {
+    const li = document.createElement('li');
+    li.textContent = `${e.date}: ${e.title}`;
+    container.appendChild(li);
+  });
+}
+
+function renderMedia(id, media) {
+  const container = document.getElementById(id);
+  container.innerHTML = '';
+  media.forEach(m => {
+    const link = document.createElement('a');
+    link.href = m.url;
+    link.textContent = m.url;
+    link.target = '_blank';
+    container.appendChild(link);
+  });
+}

--- a/server.js
+++ b/server.js
@@ -1,8 +1,56 @@
 const express = require('express');
 const fetch = global.fetch;
+const fs = require('fs');
+const path = require('path');
+const crypto = require('crypto');
 
 const app = express();
 app.use(express.json());
+app.use(express.static(__dirname));
+
+const contentFile = path.join(__dirname, 'content.json');
+let sessionToken = null;
+
+app.post('/api/login', (req, res) => {
+  const { username, password } = req.body;
+  if (
+    username === process.env.ADMIN_USER &&
+    password === process.env.ADMIN_PASS
+  ) {
+    sessionToken = crypto.randomBytes(16).toString('hex');
+    res.json({ token: sessionToken });
+  } else {
+    res.status(401).json({ error: 'Invalid credentials' });
+  }
+});
+
+app.get('/api/content', (req, res) => {
+  fs.readFile(contentFile, 'utf8', (err, data) => {
+    if (err) {
+      res.json({
+        personnel: { executives: [], cabinet: [], senators: [] },
+        events: [],
+        media: []
+      });
+    } else {
+      res.json(JSON.parse(data));
+    }
+  });
+});
+
+app.put('/api/content', (req, res) => {
+  if (req.headers.authorization !== `Bearer ${sessionToken}`) {
+    res.status(401).json({ error: 'Unauthorized' });
+    return;
+  }
+  fs.writeFile(contentFile, JSON.stringify(req.body, null, 2), err => {
+    if (err) {
+      res.status(500).json({ error: 'Failed to save content' });
+    } else {
+      res.json({ status: 'ok' });
+    }
+  });
+});
 
 app.post('/api/chat', async (req, res) => {
   const apiKey = process.env.OPENAI_API_KEY;


### PR DESCRIPTION
## Summary
- add API endpoints for executive login and content storage
- introduce admin dashboard to edit personnel, events, and media
- load page content dynamically from stored data

## Testing
- `npm test`
- `node server.js` (startup)


------
https://chatgpt.com/codex/tasks/task_e_689a56a22cdc83288262e735060289e9