### PR TITLE
Use Hugging Face backend for chatbot

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,37 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@huggingface/inference": "^4.6.1",
         "express": "^5.1.0"
       }
+    },
+    "node_modules/@huggingface/inference": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@huggingface/inference/-/inference-4.6.1.tgz",
+      "integrity": "sha512-GjEYAoW88rZKthi4OTP+Lq0yi82MywVKEKm2zLDR6BePCinpDyhTPracDPBXSl4guxenYKcoKmitFjqS/zk/sg==",
+      "license": "MIT",
+      "dependencies": {
+        "@huggingface/jinja": "^0.5.1",
+        "@huggingface/tasks": "^0.19.33"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@huggingface/jinja": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@huggingface/jinja/-/jinja-0.5.1.tgz",
+      "integrity": "sha512-yUZLld4lrM9iFxHCwFQ7D1HW2MWMwSbeB7WzWqFYDWK+rEb+WldkLdAJxUPOmgICMHZLzZGVcVjFh3w/YGubng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@huggingface/tasks": {
+      "version": "0.19.34",
+      "resolved": "https://registry.npmjs.org/@huggingface/tasks/-/tasks-0.19.34.tgz",
+      "integrity": "sha512-dIl3jyeddCEFJeogJOcbhfIq1tlo3N9K4EAxG/MfkGL0l7hI2kfs91Ut+1h6i09TQM8A9XM91NV7Jz6PgfWE7Q==",
+      "license": "MIT"
     },
     "node_modules/accepts": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "type": "commonjs",
   "dependencies": {
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "@huggingface/inference": "^4.6.1"
   }
 }


### PR DESCRIPTION
## Summary
- Replace OpenAI chat completions with Hugging Face inference backend
- Add `@huggingface/inference` dependency for chat completions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a719bc5d883289acca7e425787819