### PR TITLE
Use modal admin login with icon trigger

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -9,12 +9,7 @@
 </head>
 <body>
   <div class="wrapper">
-    <h1>Executive Login</h1>
-    <div id="login">
-      <input id="username" placeholder="Username" />
-      <input id="password" type="password" placeholder="Password" />
-      <button id="login-btn">Login</button>
-    </div>
+    <h1>Executive Editor</h1>
     <div id="editor" style="display:none;">
       <h2>Executives</h2>
       <div id="executives-form"></div>

--- a/css/styles.css
+++ b/css/styles.css
@@ -121,6 +121,41 @@ nav a {
   display: block;
 }
 
+/* Admin login button */
+.admin-icon {
+  background: transparent;
+  border: none;
+  color: var(--light);
+  cursor: pointer;
+  font-size: 1.25rem;
+}
+
+/* Login modal */
+.login-modal {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  justify-content: center;
+  align-items: center;
+  z-index: 2000;
+}
+
+.login-modal .modal-content {
+  background: var(--light);
+  padding: 1rem;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 240px;
+}
+
+.login-modal .close {
+  align-self: flex-end;
+  cursor: pointer;
+}
+
 nav a:hover,
 nav a:focus {
   background-color: var(--secondary);

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
   <script src="/js/main.js" defer></script>
   <script src="/js/chatbot.js" defer></script>
+  <script src="/js/login.js" defer></script>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet" />
@@ -26,7 +27,9 @@
         <a href="/About/">About</a>
         <a href="/Events/">Events</a>
         <a href="/Media/">Media</a>
-        <a href="/admin.html">Admin</a>
+        <button id="admin-login-btn" class="admin-icon" aria-label="Admin Login">
+          <i class="fa-solid fa-user"></i>
+        </button>
       </nav>
       <div class="hero-content">
         <h1>Charleston Southern University SGA</h1>
@@ -72,6 +75,17 @@
       <p>© 2025 Charleston Southern University Student Government Association. All rights reserved.</p>
     </footer>
     
+  </div>
+
+  <!-- Admin Login Modal -->
+  <div id="login-modal" class="login-modal">
+    <div class="modal-content">
+      <span id="close-login" class="close">&times;</span>
+      <h2>Admin Login</h2>
+      <input id="login-username" placeholder="Username" />
+      <input id="login-password" type="password" placeholder="Password" />
+      <button id="login-submit">Login</button>
+    </div>
   </div>
 </body>
 </html>

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,18 +1,6 @@
 let token = localStorage.getItem('token');
 let contentData = null;
 
-async function apiLogin(username, password) {
-  const res = await fetch('/api/login', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ username, password })
-  });
-  if (!res.ok) throw new Error('Login failed');
-  const data = await res.json();
-  token = data.token;
-  localStorage.setItem('token', token);
-}
-
 async function loadContent() {
   const res = await fetch('/api/content');
   contentData = await res.json();
@@ -120,26 +108,16 @@ function addHandlers() {
 }
 
 document.addEventListener('DOMContentLoaded', async () => {
-  document.getElementById('login-btn').addEventListener('click', async () => {
-    const u = document.getElementById('username').value;
-    const p = document.getElementById('password').value;
-    try {
-      await apiLogin(u, p);
-      await loadContent();
-      document.getElementById('login').style.display = 'none';
-      document.getElementById('editor').style.display = 'block';
-      renderAll();
-      addHandlers();
-    } catch (e) {
-      alert('Login failed');
-    }
-  });
-
-  if (token) {
+  if (!token) {
+    window.location.href = '/';
+    return;
+  }
+  try {
     await loadContent();
-    document.getElementById('login').style.display = 'none';
     document.getElementById('editor').style.display = 'block';
     renderAll();
     addHandlers();
+  } catch (e) {
+    alert('Failed to load content');
   }
 });

--- a/js/login.js
+++ b/js/login.js
@@ -1,0 +1,36 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const modal = document.getElementById('login-modal');
+  const openBtn = document.getElementById('admin-login-btn');
+  const closeBtn = document.getElementById('close-login');
+
+  if (openBtn) {
+    openBtn.addEventListener('click', () => {
+      modal.style.display = 'flex';
+    });
+  }
+
+  if (closeBtn) {
+    closeBtn.addEventListener('click', () => {
+      modal.style.display = 'none';
+    });
+  }
+
+  document.getElementById('login-submit').addEventListener('click', async () => {
+    const username = document.getElementById('login-username').value;
+    const password = document.getElementById('login-password').value;
+    try {
+      const res = await fetch('/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ username, password })
+      });
+      if (!res.ok) throw new Error('Login failed');
+      const data = await res.json();
+      localStorage.setItem('token', data.token);
+      modal.style.display = 'none';
+      window.location.href = '/admin.html';
+    } catch (e) {
+      alert('Login failed');
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- replace header Admin link with user icon that opens modal login
- add modal login script and styles; redirect to admin editor after successful login
- simplify admin editor page to assume pre-authenticated token

## Testing
- `npm test`
- `curl -s -X POST http://localhost:3000/api/login -H 'Content-Type: application/json' -d '{"username":"SGAexecutive","password":"eVery0neshouldjoin5GA"}'`


------
https://chatgpt.com/codex/tasks/task_e_689a868aa2248328b5f406c549737e30