### PR TITLE
fix: ensure API routes accessible

### DIFF
--- a/server.js
+++ b/server.js
@@ -7,7 +7,6 @@ const multer = require('multer');
 
 const app = express();
 app.use(express.json());
-app.use(express.static(__dirname));
 
 const contentFile = path.join(__dirname, 'content.json');
 let sessionToken = null;
@@ -105,6 +104,9 @@ app.post('/api/chat', async (req, res) => {
     res.status(500).json({ error: 'Failed to fetch from Hugging Face' });
   }
 });
+
+// Serve static files after API routes to ensure the endpoints work properly
+app.use(express.static(__dirname));
 
 const port = process.env.PORT || 3000;
 app.listen(port, () => {


### PR DESCRIPTION
## Summary
- move static file middleware below API routes so admin login endpoint is reachable

## Testing
- `npm test`
- `curl -s -X POST -H "Content-Type: application/json" -d '{"username":"SGAexecutive","password":"eVery0neshouldjoin5GA"}' http://localhost:3000/api/login`


------
https://chatgpt.com/codex/tasks/task_e_689aaed254b88328b8f1d60fbd2f8f2f