### PR TITLE
fix: allow cross-origin admin login

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -1,8 +1,13 @@
 let token = localStorage.getItem('token');
 let contentData = null;
 
+// Determine the base URL so the API can be reached even when the page is
+// opened directly from disk (file:// protocol).
+const origin = window.location.origin;
+const baseUrl = origin && origin.startsWith('http') ? origin : 'http://localhost:3000';
+
 async function loadContent() {
-  const res = await fetch('/api/content');
+  const res = await fetch(`${baseUrl}/api/content`);
   contentData = await res.json();
 }
 
@@ -45,7 +50,7 @@ function renderMediaSection() {
       if (!file) return;
       const formData = new FormData();
       formData.append('media', file);
-      const res = await fetch('/api/upload', {
+      const res = await fetch(`${baseUrl}/api/upload`, {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}` },
         body: formData
@@ -68,7 +73,7 @@ function renderAll() {
 }
 
 async function saveContent() {
-  const res = await fetch('/api/content', {
+  const res = await fetch(`${baseUrl}/api/content`, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',

--- a/js/login.js
+++ b/js/login.js
@@ -3,6 +3,11 @@ document.addEventListener('DOMContentLoaded', () => {
   const openBtn = document.getElementById('admin-login-btn');
   const closeBtn = document.getElementById('close-login');
 
+  // Determine the base URL so the API can be reached even when the page is
+  // opened directly from disk (file:// protocol).
+  const origin = window.location.origin;
+  const baseUrl = origin && origin.startsWith('http') ? origin : 'http://localhost:3000';
+
   if (openBtn) {
     openBtn.addEventListener('click', () => {
       modal.style.display = 'flex';
@@ -19,7 +24,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const username = document.getElementById('login-username').value;
     const password = document.getElementById('login-password').value;
     try {
-      const res = await fetch('/api/login', {
+      const res = await fetch(`${baseUrl}/api/login`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ username, password })

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@huggingface/inference": "^4.6.1",
+        "cors": "^2.8.5",
         "express": "^5.1.0",
         "multer": "^1.4.5-lts.1"
       }
@@ -195,6 +196,19 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "type": "commonjs",
   "dependencies": {
     "@huggingface/inference": "^4.6.1",
+    "cors": "^2.8.5",
     "express": "^5.1.0",
     "multer": "^1.4.5-lts.1"
   }

--- a/server.js
+++ b/server.js
@@ -4,10 +4,11 @@ const path = require('path');
 const crypto = require('crypto');
 const { HfInference } = require('@huggingface/inference');
 const multer = require('multer');
+const cors = require('cors');
 
 const app = express();
+app.use(cors());
 app.use(express.json());
-app.use(express.static(__dirname));
 
 const contentFile = path.join(__dirname, 'content.json');
 let sessionToken = null;
@@ -105,6 +106,9 @@ app.post('/api/chat', async (req, res) => {
     res.status(500).json({ error: 'Failed to fetch from Hugging Face' });
   }
 });
+
+// Serve static files after API routes to ensure the endpoints work properly
+app.use(express.static(__dirname));
 
 const port = process.env.PORT || 3000;
 app.listen(port, () => {


### PR DESCRIPTION
## Summary
- enable CORS so admin login works when site opened from disk or other origins
- add cors dependency

## Testing
- `npm test`
- `curl -i -H 'Origin: null' -H 'Content-Type: application/json' -d '{"username":"SGAexecutive","password":"eVery0neshouldjoin5GA"}' http://localhost:3000/api/login`


------
https://chatgpt.com/codex/tasks/task_e_689aaed254b88328b8f1d60fbd2f8f2f